### PR TITLE
Added filter parameter to ffmpeg to eliminate warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ How to
 * To save the Streaming, go to http://twitch.tv/settings/videos and check **Archive Broadcasts - Automatically archive my broadcasts**
 * Open now the twitch.sh and edit the settings
 
-        Value              Example                  Description                       
+        Value              Example                  Description
         ------------------ ------------------------ ---------------------------------------------------------------------------------------------------------
         OUTRES             "1280x720"               Twitch Output Resolution ("1920x1080" should be the maximum resolution)
         FPS                "24"                     Frame per Seconds (Suggested 24, 25, 30 or 60)
@@ -45,7 +45,7 @@ How to
         SERVER             "live" or "live-fra"     Twitch Server list at http://bashtech.net/twitch/ingest.php
         CBR                "1000k" to "3000k"       Constant bitrate. Increase this to get a better pixel quality (Twitch suggest between 1000k to 3000k)
         ALWAYS_FULLSCREEN  "false" or "true"        Change this to 'true' if you want to go always on FULLSCREEN, this will disable the output.
-        SUPPRESS_OUTPUT    "false" or "true"        Change this to 'true' if you want to hide your STREAM_KEY, for security purpose. This will not affect 
+        SUPPRESS_OUTPUT    "false" or "true"        Change this to 'true' if you want to hide your STREAM_KEY, for security purpose. This will not affect
                                                     the ALWAYS_FULLSCREEN option. ALWAYS_FULLSCREEN will always disable the output.
         FILE_VIDEO         "My_stream.flv"          File name to redirect the stream if there's the -save arg (go to the How To to see how it works)
         SET_XY             "10,100"                 Position of the Window on the screen (X,Y) and will be used only if the -coords option is called.
@@ -56,7 +56,7 @@ How to
 * Open the game that you want to stream and set window mode.
 * Open a terminal, browse to the twitch script directory and run the script
 
-        $ ./twitch_ffmpeg.sh 
+        $ ./twitch_ffmpeg.sh
 
 * Avconv script is deprecated. It can give you errors
 * Click with your Mouse on the game window
@@ -72,10 +72,10 @@ Additional How to
 
 * You can run the scripts with some arguments (you can use a combination of these):
 
-        Value              Description                       
+        Value              Description
         ------------------ -------------------------------------------------------------------------------
          -h                Display the usage screen
-         -fullscreen       Run the script in FULLSCREEN mode 
+         -fullscreen       Run the script in FULLSCREEN mode
          -window           Run the script in WINDOW mode
          -coords           Set the screen resolution, by using SET_XY SET_INRES defined inside the script
          -save             Save the video to the file FILE_VIDEO instead of streaming it
@@ -108,6 +108,8 @@ Build it with the following build options:
 
 	./configure --disable-ffplay --disable-ffprobe --disable-ffserver --enable-libfaac --enable-libmp3lame --enable-libv4l2 --enable-libx264 --enable-x11grab --enable-libpulse --enable-librtmp --enable-gpl --enable-nonfree --disable-yasm  --extra-libs="-lasound" && make
 
+Complete Guide on how to compile ffmpeg: https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu
+
 ###Suggested:
 
         pavucontrol
@@ -116,10 +118,10 @@ FAQ
 ---
 * How do i choose the bitrate?
 
-	The optimal bitrate can be calculated in this way: `bitrate = Width*Height/144`, 
+	The optimal bitrate can be calculated in this way: `bitrate = Width*Height/144`,
 	an example `720*480/144 = 2400 (k)` but if you get a bitrate above 5000(k)
 	like `1920*1080/144=2073456(k = ~2073 M)` choose 5000k, because 6000k is
-	DVD quality. 
+	DVD quality.
 
 * I see some errors after `Stopping Audio (Don't worry if you see errors here)`, should i worry about this?
 
@@ -146,5 +148,3 @@ Screenshot:
 -----------
 
 ![Screenshot from twitch.tv](https://raw.github.com/wargio/Twitch-Streamer-Linux/master/Screenshots/Screenshot.png)
-
-

--- a/twitch_ffmpeg.sh
+++ b/twitch_ffmpeg.sh
@@ -173,7 +173,7 @@ streamWebcam(){
                 WEBCAM_XY="$(($(echo $INRES | awk -F"x" '{ print $1 }') - $(echo $WEBCAM_WH | awk -F":" '{ print $1 }') - 10)):10"
                 echo "There isn't a WEBCAM_XY in the options, i'll generate the standard one ($WEBCAM_XY)"
         fi
-        $FFMPEG_PATH -f x11grab -s $INRES -framerate "$FPS" -i :0.0+$TOPXY -f alsa -i pulse -f flv -ac 2 -ar $AUDIO_RATE -vcodec libx264 -force_key_frames "expr:gte(t,n_forced*$KEY_FRAME)" -g $GOP -keyint_min $GOPMIN -b $CBR -minrate $CBR -maxrate $CBR -pix_fmt yuv420p -s $OUTRES -preset $QUALITY -tune film  -acodec libmp3lame -threads $THREADS -vf "movie=$WEBCAM:f=video4linux2, scale=$WEBCAM_WH , setpts=PTS-STARTPTS [WebCam]; [in] setpts=PTS-STARTPTS [Screen]; [Screen][WebCam] overlay=$WEBCAM_XY [out]" -strict normal -bufsize $CBR $LOGLEVEL_ARG "rtmp://$SERVER.twitch.tv/app/$STREAM_KEY"
+        $FFMPEG_PATH -f x11grab -s $INRES -framerate "$FPS" -i :0.0+$TOPXY -f alsa -i pulse -f flv -ac 2 -ar $AUDIO_RATE -vcodec libx264 -filter:v fps="$FPS" -force_key_frames "expr:gte(t,n_forced*$KEY_FRAME)" -g $GOP -keyint_min $GOPMIN -b $CBR -minrate $CBR -maxrate $CBR -pix_fmt yuv420p -s $OUTRES -preset $QUALITY -tune film  -acodec libmp3lame -threads $THREADS -vf "movie=$WEBCAM:f=video4linux2, scale=$WEBCAM_WH , setpts=PTS-STARTPTS [WebCam]; [in] setpts=PTS-STARTPTS [Screen]; [Screen][WebCam] overlay=$WEBCAM_XY [out]" -strict normal -bufsize $CBR $LOGLEVEL_ARG "rtmp://$SERVER.twitch.tv/app/$STREAM_KEY"
         APP_RETURN=$?
 }
 
@@ -181,7 +181,7 @@ streamNoWebcam(){
         echo "Webcam NOT found!! ("$WEBCAM")"
         echo "You should be online! Check on http://twitch.tv/ (Press CTRL+C to stop)"
         echo " "
-        $FFMPEG_PATH -f x11grab -s $INRES -framerate "$FPS" -i :0.0+$TOPXY -f alsa -i pulse -f flv -ac 2 -ar $AUDIO_RATE -vcodec libx264 -force_key_frames "expr:gte(t,n_forced*$KEY_FRAME)" -g $GOP -keyint_min $GOPMIN  -b:v $CBR -minrate $CBR -maxrate $CBR -pix_fmt yuv420p -s $OUTRES -preset $QUALITY -tune film -acodec libmp3lame -threads $THREADS -strict normal -bufsize $CBR $LOGLEVEL_ARG "rtmp://$SERVER.twitch.tv/app/$STREAM_KEY"
+        $FFMPEG_PATH -f x11grab -s $INRES -framerate "$FPS" -i :0.0+$TOPXY -f alsa -i pulse -f flv -ac 2 -ar $AUDIO_RATE -vcodec libx264 -filter:v fps="$FPS" -force_key_frames "expr:gte(t,n_forced*$KEY_FRAME)" -g $GOP -keyint_min $GOPMIN  -b:v $CBR -minrate $CBR -maxrate $CBR -pix_fmt yuv420p -s $OUTRES -preset $QUALITY -tune film -acodec libmp3lame -threads $THREADS -strict normal -bufsize $CBR $LOGLEVEL_ARG "rtmp://$SERVER.twitch.tv/app/$STREAM_KEY"
         APP_RETURN=$?
 }
 
@@ -203,7 +203,7 @@ saveStreamNoWebcam(){
         echo "Webcam NOT found!! ("$WEBCAM")"
         echo "You should be online! Check on http://twitch.tv/ (Press CTRL+C to stop)"
         echo " "
-        $FFMPEG_PATH -f x11grab -s $INRES -framerate "$FPS" -i :0.0+$TOPXY -f alsa -i pulse -f flv -ac 2 -ar $AUDIO_RATE -vcodec libx264 -force_key_frames "expr:gte(t,n_forced*$KEY_FRAME)" -g $GOP -keyint_min $GOPMIN  -b:v $CBR -minrate $CBR -maxrate $CBR -pix_fmt yuv420p -s $OUTRES -preset $QUALITY -tune film -acodec libmp3lame -threads $THREADS -strict normal -bufsize $CBR $LOGLEVEL_ARG $FILE_VIDEO
+        $FFMPEG_PATH -f x11grab -s $INRES -framerate "$FPS" -i :0.0+$TOPXY -f alsa -i pulse -f flv -ac 2 -ar $AUDIO_RATE -vcodec libx264 -filter:v fps="$FPS" -force_key_frames "expr:gte(t,n_forced*$KEY_FRAME)" -g $GOP -keyint_min $GOPMIN  -b:v $CBR -minrate $CBR -maxrate $CBR -pix_fmt yuv420p -s $OUTRES -preset $QUALITY -tune film -acodec libmp3lame -threads $THREADS -strict normal -bufsize $CBR $LOGLEVEL_ARG $FILE_VIDEO
         APP_RETURN=$?
 }
 
@@ -229,8 +229,8 @@ doDefaults(){
 loadModule(){
 	MODULE_LOAD1=$(pactl load-module module-null-sink sink_name=GameAudio sink_properties=device.description="GameAudio") # For Game Audio
 	MODULE_LOAD2=$(pactl load-module module-null-sink sink_name=MicAudio sink_properties=device.description="MicAudio") # For Mic Audio
-	pactl load-module module-device-manager >> /dev/null  
-	pactl load-module module-loopback sink=GameAudio >> /dev/null      
+	pactl load-module module-device-manager >> /dev/null
+	pactl load-module module-loopback sink=GameAudio >> /dev/null
 	pactl load-module module-loopback sink=MicAudio >> /dev/null
 }
 


### PR DESCRIPTION
Added -filter:v fps="$FPS" option to ffmpeg so to make warnings disappear. This seems to be a new 'feature' pushed in recently and would flood the screen with messages like

    Past duration 0.999474 too large    9990kB time=00:02:43.17 bitrate= 501.5kbits/s dup=0 drop=23 speed=1.01x    
    Past duration 0.999519 too large                                                                                                                                                   
    Past duration 0.999748 too large                                                                                                                                                   
    Past duration 0.999474 too large                                                                                                                                                   
    Past duration 0.999443 too large                                                                                                                                                   
    Past duration 0.999718 too large                                                                                                                                                   
    Past duration 0.999245 too large                                                                                                                                                   
    Past duration 0.999718 too large                                        

Added reference to official ffmpeg.org guide on how to grab dependencies and compile ffmpeg

More differences are due to whitespace chopping to the end of the lines, which is a feature of some text processors, please ignore.
